### PR TITLE
Use `extensionPack` instead of `extensionDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "0.1.8",
     "publisher": "waderyan",
     "engines": {
-        "vscode": "^1.10.0"
+       "vscode": "^1.26.0"
     },
     "icon": "nodejs-dark-icon.png",
     "galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bugs": {
         "url": "https://github.com/waderyan/nodejs-extension-pack/issues"
     },
-    "extensionDependencies": [
+    "extensionPack": [
         "dbaeumer.vscode-eslint",
         "xabikos.javascriptsnippets",
         "jasonnutter.search-node-modules",


### PR DESCRIPTION
From release v1.26, defining an Extension Pack now uses a new property called `extensionPack` instead of `extensionDependencies` in package.json. This is because extensionDependencies is mainly used to define functional dependencies and an Extension Pack should not have any functional dependencies with its bundled extensions and they should be manageable independent of the pack. 

So please use `extensionPack` property for defining the pack.

For more details refer to [Release notes](https://code.visualstudio.com/updates/v1_26#_extension-packs-revisited)