### PR TITLE
add vscode-goto-node-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ These are some of my favorite extensions to make Node.js development easier and 
 * [Search node_modules](https://marketplace.visualstudio.com/items?itemName=jasonnutter.search-node-modules) - Quickly search for node modules in your project. 
 * [NPM IntelliSense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense) - Adds IntelliSense for npm modules in your code. 
 * [Path IntelliSense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense) - Autocompletes filenames in your code. 
+* [goto node modules](https://marketplace.visualstudio.com/items?itemName=ravenq.vscode-goto-node-modules) - Goto node modules from js code. 
 
 ## Want to see your extension added?
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "jasonnutter.search-node-modules",
         "eg2.vscode-npm-script",
         "christian-kohler.npm-intellisense",
-        "christian-kohler.path-intellisense"
+        "christian-kohler.path-intellisense",
+        "ravenq.vscode-goto-node-modules"
     ]
 }


### PR DESCRIPTION
Hi.

I publish a plugin in the marketplace: https://marketplace.visualstudio.com/items?itemName=ravenq.vscode-goto-node-modules.

and want add this plugin to the pack.

The plugin make it easy to goto the dependence pack in the node_modules fold like goto definition.

Thanks!