### PR TITLE
Remove npm extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ These are some of my favorite extensions to make Node.js development easier and 
 ## Extensions Included
 
 * [ES Lint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) - Integrates [ESLint](http://eslint.org/) into VS Code. 
-* [npm](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script) - Run npm scripts from the command palatte and validate the installed modules defined in `package.json`.
 * [JavaScript (ES6) Snippets](https://marketplace.visualstudio.com/items?itemName=xabikos.JavaScriptSnippets) - Adds code snippets for JavaScript development in ES6 syntax. 
 * [Search node_modules](https://marketplace.visualstudio.com/items?itemName=jasonnutter.search-node-modules) - Quickly search for node modules in your project. 
 * [NPM IntelliSense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense) - Adds IntelliSense for npm modules in your code. 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "dbaeumer.vscode-eslint",
         "xabikos.javascriptsnippets",
         "jasonnutter.search-node-modules",
-        "eg2.vscode-npm-script",
         "christian-kohler.npm-intellisense",
         "christian-kohler.path-intellisense"
     ]


### PR DESCRIPTION
As detailed on the extension marketplace (https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script), the npm extension has been deprecated. VS Code now natively provides support for running npm scripts, so it should be removed from this pack